### PR TITLE
add setting to be able to skip mandatory client cert auth

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -38,9 +38,10 @@ type NomadServer struct {
 	TLS     *NomadServerTLS `hcl:"tls,block"`
 }
 type ProxyTLS struct {
-	CertFile string `hcl:"cert_file"`
-	KeyFile  string `hcl:"key_file"`
-	CaFile   string `hcl:"ca_file"`
+	CertFile     string `hcl:"cert_file"`
+	KeyFile      string `hcl:"key_file"`
+	CaFile       string `hcl:"ca_file"`
+	NoClientCert bool   `hcl:"no_client_cert,optional"`
 }
 type Config struct {
 	Port int    `hcl:"port,optional"`

--- a/nacp.go
+++ b/nacp.go
@@ -512,13 +512,13 @@ func createTlsConfig(c *config.Config) (*tls.Config, error) {
 	}
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caCert)
-	tlsConfig := &tls.Config{
-		ClientCAs: caCertPool,
-	}
+	clientAuth := tls.RequireAndVerifyClientCert
 	if c.Tls.NoClientCert {
-		tlsConfig.ClientAuth = tls.NoClientCert
-	} else {
-		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+		clientAuth = tls.NoClientCert
+	}
+	tlsConfig := &tls.Config{
+		ClientCAs:  caCertPool,
+		ClientAuth: clientAuth,
 	}
 
 	return tlsConfig, nil

--- a/nacp.go
+++ b/nacp.go
@@ -470,7 +470,7 @@ func buildServer(c *config.Config, appLogger hclog.Logger) (*http.Server, error)
 	var tlsConfig *tls.Config
 
 	if c.Tls != nil && c.Tls.CaFile != "" {
-		tlsConfig, err = createTlsConfig(c.Tls.CaFile)
+		tlsConfig, err = createTlsConfig(c)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create tls config: %w", err)
 
@@ -505,16 +505,20 @@ func buildConfig(logger hclog.Logger) *config.Config {
 	return c
 }
 
-func createTlsConfig(caFile string) (*tls.Config, error) {
-	caCert, err := os.ReadFile(caFile)
+func createTlsConfig(c *config.Config) (*tls.Config, error) {
+	caCert, err := os.ReadFile(c.Tls.CaFile)
 	if err != nil {
 		return nil, err
 	}
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caCert)
 	tlsConfig := &tls.Config{
-		ClientCAs:  caCertPool,
-		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs: caCertPool,
+	}
+	if c.Tls.NoClientCert {
+		tlsConfig.ClientAuth = tls.NoClientCert
+	} else {
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 	}
 
 	return tlsConfig, nil


### PR DESCRIPTION
hey @mxab 

we have a usecase where we don't have client certs, so making that optional might be useful for others as well
the default behaviour remains the same